### PR TITLE
Fix issue where subpackages are not installed correctly

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -37,7 +37,7 @@ setup(
     author="Matti A. Eskelinen",
     author_email='matti.a.eskelinen@student.jyu.fi',
     url='https://github.com/silmae/fpipy',
-    packages=find_packages(include=['fpipy']),
+    packages=find_packages(),
     scripts=['bin/raw2rad'],
     include_package_data=True,
     install_requires=requirements,


### PR DESCRIPTION
Previously find_packages method installed only the top package when installed using pip

This led to a crash when importing fpipy
Now "data" subpackage is included in the installation
